### PR TITLE
chore!: rebrand as onionpipe

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 /Dockerfile
-/oniongrok
+/onionpipe
 /.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/oniongrok*
+/onionpipe*
 data-dir-*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,5 @@
 builds:
-- binary: oniongrok
+- binary: onionpipe
   goos:
   - darwin
   - linux
@@ -9,7 +9,7 @@ builds:
 brews:
 - tap:
     owner: cmars
-    name: homebrew-oniongrok
+    name: homebrew-onionpipe
     branch: main
     token: "{{ .Env.TAP_GITHUB_TOKEN }}"
   dependencies:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN touch /data/.build
 
 # Deploy image
 FROM tor
-COPY --from=build /src/oniongrok /oniongrok
+COPY --from=build /src/onionpipe /onionpipe
 COPY --from=build --chown=1000 /data/ /data/
 WORKDIR /data
 USER 1000
-ENTRYPOINT [ "/oniongrok" ]
+ENTRYPOINT [ "/onionpipe" ]

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 
-all: oniongrok
+all: onionpipe
 
-oniongrok_libtor:
+onionpipe_libtor:
 	go build -o $@ -v -x -tags "staticOpenssl,staticZlib,staticLibevent,libtor" .
 	strip $@
 
-oniongrok_embed:
+onionpipe_embed:
 	go build -o $@ -v -x -tags "embed" .
 
-oniongrok:
+onionpipe:
 	go build -o $@ .
 
 .PHONY: docker
 docker:
-	docker build -t oniongrok .
+	docker build -t onionpipe .
 
 .PHONY: test
 test:
@@ -27,4 +27,4 @@ coverage:
 
 .PHONY: clean
 clean:
-	$(RM) oniongrok
+	$(RM) onionpipe

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# oniongrok
+# onionpipe
 
 Onion addresses for anything.
 
-`oniongrok` forwards ports on the local host to remote Onion addresses as Tor
+`onionpipe` forwards ports on the local host to remote Onion addresses as Tor
 hidden services and vice-versa.
 
 ### Why would I want to use this?
 
-oniongrok is a decentralized way to create virtually unstoppable global network
+onionpipe is a decentralized way to create virtually unstoppable global network
 tunnels.
 
 For example, you might want to securely publish and access a personal service
@@ -15,67 +15,67 @@ from anywhere in the world, across all sorts of network obstructions -- your
 ISP doesn't allow ingress traffic to your home lab, your clients might be in
 heavily firewalled environments (public WiFi, mobile tether), etc.
 
-With oniongrok, that service doesn't need a public IPv4 or IPv6 ingress. You'll
+With onionpipe, that service doesn't need a public IPv4 or IPv6 ingress. You'll
 eventually be able to restrict access with auth tokens. And you don't need to
 rely on, and share your personal data with for-profit services (like Tailscale,
 ZeroTier, etc.) to get to it.
 
 ### What can I do with it right now?
 
-oniongrok sets up socket forwarding tunnels. It's like `socat(1)`, for onions.
+onionpipe sets up socket forwarding tunnels. It's like `socat(1)`, for onions.
 
 #### Export services on local networks to onion addresses
 
 Export localhost port 8000 to a temporary, one-time remote onion address.
 ```
-oniongrok 8000
+onionpipe 8000
 ```
 
 Export localhost port 8000 to temporary remote onion port 80. `~` is shorthand
 for the forward between source~destination.
 ```
-oniongrok 8000~80
+onionpipe 8000~80
 ```
 
 Export localhost port 8000 to a persistent remote onion address nicknamed
 'my-app'.
 ```
-oniongrok 8000~80@my-app
+onionpipe 8000~80@my-app
 ```
 
 Nicknames can be re-used in multiple forwarding expressions to reference the
 same onion address. Let's set up a little web forum for our Minecraft server.
 ```
-oniongrok 8000~80@minecraft 25565@minecraft
+onionpipe 8000~80@minecraft 25565@minecraft
 ```
 
 All the forwards without nicknames use the same temporary address.
 ```
-oniongrok 192.168.1.100:8000~80,8080,9000 9090
+onionpipe 192.168.1.100:8000~80,8080,9000 9090
 ```
 
 Export a UNIX socket to an onion address.
 ```
-oniongrok /run/server.sock~80
+onionpipe /run/server.sock~80
 ```
 
 Export to a non-anonymous remote onion service, trading network privacy for
 possibly reduced latency.
 ```
-oniongrok --anonymous=false 8000
+onionpipe --anonymous=false 8000
 ```
 
 #### Import onion services to local network interfaces.
 
 Import a remote onion's port 80 to localhost port 80.
 ```
-oniongrok xxx.onion:80
+onionpipe xxx.onion:80
 ```
 
 Import remote onion port 80 to local port 80 on all interfaces. This can be
 used for creating an ingress to the onion on public networks.
 ```
-oniongrok xxx.onion:80~0.0.0.0:80
+onionpipe xxx.onion:80~0.0.0.0:80
 ```
 
 Running with Docker is simple and easy, the only caveat is that its the
@@ -83,12 +83,12 @@ container forwarding, so adjust local addresses accordingly.
 
 Forward port 80 on Docker host.
 ```
-docker run --rm ghcr.io/cmars/oniongrok:main host.docker.internal:80
+docker run --rm ghcr.io/cmars/onionpipe:main host.docker.internal:80
 ```
 
 If you're using Podman, exposing the local host network is another option.
 ```
-podman run --network=host --rm ghcr.io/cmars/oniongrok:main 8000 
+podman run --network=host --rm ghcr.io/cmars/onionpipe:main 8000 
 ```
 
 Because local forwarding addresses are DNS resolved, it's very easy to publish
@@ -103,7 +103,7 @@ is great for securing personal services over Tor. How to use it:
 Alice creates a new client auth public key pair.
 
 ```
-oniongrok client new alice
+onionpipe client new alice
 ```
 
 ```
@@ -118,7 +118,7 @@ Alice shares this public key with Bob, who forwards an onion service that only
 Alice can use.
 
 ```
-oniongrok --require-auth p2pof7vumwsrqqavtovfwqqaw6cqzvtqqe7cjvxt754k6j7blufa 8000~80@test
+onionpipe --require-auth p2pof7vumwsrqqavtovfwqqaw6cqzvtqqe7cjvxt754k6j7blufa 8000~80@test
 ```
 
 ```
@@ -130,7 +130,7 @@ Alice can use her client private key to connect to this onion and forward to a
 local port.
 
 ```
-oniongrok --auth alice sd6aq2r6jvuoeisrudq7jbqufjh6nck5buuzjmgalicgwrobgfj4lkqd.onion:80~7000
+onionpipe --auth alice sd6aq2r6jvuoeisrudq7jbqufjh6nck5buuzjmgalicgwrobgfj4lkqd.onion:80~7000
 ```
 
 ```
@@ -145,12 +145,12 @@ tap and Docker image.
 
 #### Homebrew
 
-    brew tap cmars/oniongrok
-    brew install oniongrok
+    brew tap cmars/onionpipe
+    brew install onionpipe
 
 #### Docker
 
-The provided `Dockerfile` builds a minimal image that can run oniongrok in a
+The provided `Dockerfile` builds a minimal image that can run onionpipe in a
 container with the latest Tor release from the Tor Project. Build and runtime
 is Debian-based.
 
@@ -158,9 +158,9 @@ is Debian-based.
 
 In a local clone of this project,
 
-    make oniongrok
+    make onionpipe
 
-The built binary `oniongrok` will require a `tor` daemon executable to be in
+The built binary `onionpipe` will require a `tor` daemon executable to be in
 your `$PATH`.
 
 #### Static standalone binary with libtor
@@ -171,7 +171,7 @@ are some quirks; see comments in `tor/init_libtor.go` for details.
 
 In a local clone of this project,
 
-    make oniongrok_libtor
+    make onionpipe_libtor
 
 This will take a long time the first time you build, because it compiles CGO
 wrappers for Tor and its dependencies.
@@ -191,7 +191,7 @@ dependencies installed into your shell context.
 Operate from a yaml file.
 
 ```
-oniongrok --config config.yaml
+onionpipe --config config.yaml
 ```
 
 Considering a TUI.

--- a/app/app.go
+++ b/app/app.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/urfave/cli/v2"
 
-	"github.com/cmars/oniongrok/secrets"
+	"github.com/cmars/onionpipe/secrets"
 )
 
 var forwardFlags = []cli.Flag{
@@ -42,13 +42,13 @@ func defaultSecretsPath() string {
 		log.Printf("failed to locate home directory: %v", err)
 		return ""
 	}
-	return filepath.Join(home, ".local", "share", "oniongrok", "secrets.json")
+	return filepath.Join(home, ".local", "share", "onionpipe", "secrets.json")
 }
 
-// App returns a new oniongrok command line app.
+// App returns a new onionpipe command line app.
 func App() *cli.App {
 	return &cli.App{
-		Name:   "oniongrok",
+		Name:   "onionpipe",
 		Usage:  "forward services through Tor; .onion addresses for anything",
 		Flags:  forwardFlags,
 		Action: Forward,

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -8,9 +8,9 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/mitchellh/go-homedir"
 
-	"github.com/cmars/oniongrok/config"
-	"github.com/cmars/oniongrok/forwarding"
-	"github.com/cmars/oniongrok/tor"
+	"github.com/cmars/onionpipe/config"
+	"github.com/cmars/onionpipe/forwarding"
+	"github.com/cmars/onionpipe/tor"
 )
 
 func init() {
@@ -49,7 +49,7 @@ func TestApp(t *testing.T) {
 		home := c.Mkdir()
 		c.Setenv("HOME", home)
 		fwdSvc.fwds = nil
-		err := App().Run([]string{"oniongrok", "8080"})
+		err := App().Run([]string{"onionpipe", "8080"})
 		c.Assert(err, qt.IsNil)
 
 		c.Assert(fwdSvc.fwds, qt.HasLen, 1)
@@ -61,7 +61,7 @@ func TestApp(t *testing.T) {
 		home := c.Mkdir()
 		c.Setenv("HOME", home)
 		fwdSvc.fwds = nil
-		err := App().Run([]string{"oniongrok", "8080@test"})
+		err := App().Run([]string{"onionpipe", "8080@test"})
 		c.Assert(err, qt.IsNil)
 
 		c.Assert(fwdSvc.fwds, qt.HasLen, 1)
@@ -75,14 +75,14 @@ func TestApp(t *testing.T) {
 		home := c.Mkdir()
 		c.Setenv("HOME", home)
 		fwdSvc.fwds = nil
-		err := App().Run([]string{"oniongrok", "--anonymous=false", "8080@test"})
+		err := App().Run([]string{"onionpipe", "--anonymous=false", "8080@test"})
 		c.Assert(err, qt.IsNil)
 
 		c.Assert(fwdSvc.fwds, qt.HasLen, 1)
 		c.Assert(fwdSvc.fwds[0].Description(fwdSvc.onions), qt.Equals, "127.0.0.1:8080 => abc.onion:8080")
 		_, err = os.Stat(defaultSecretsPath())
 		c.Assert(os.IsNotExist(err), qt.IsTrue)
-		_, err = os.Stat(home + "/.local/share/oniongrok/secrets.not-anonymous.json")
+		_, err = os.Stat(home + "/.local/share/onionpipe/secrets.not-anonymous.json")
 		c.Assert(err, qt.IsNil)
 	})
 }

--- a/app/client.go
+++ b/app/client.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cmars/oniongrok/secrets"
 	"github.com/urfave/cli/v2"
+
+	"github.com/cmars/onionpipe/secrets"
 )
 
 // ListClientKeys implements the `client ls` command.

--- a/app/client_test.go
+++ b/app/client_test.go
@@ -7,7 +7,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/cmars/oniongrok/secrets"
+	"github.com/cmars/onionpipe/secrets"
 )
 
 func TestClientCommands(t *testing.T) {
@@ -21,7 +21,7 @@ func TestClientCommands(t *testing.T) {
 		c.Patch(&os.Stdout, out)
 		go func() {
 			defer out.Close()
-			err := App().Run([]string{"oniongrok", "client"})
+			err := App().Run([]string{"onionpipe", "client"})
 			c.Assert(err, qt.IsNil)
 		}()
 		var clients secrets.ClientsPublic
@@ -30,22 +30,22 @@ func TestClientCommands(t *testing.T) {
 		c.Assert(clients, qt.HasLen, 0)
 	})
 	c.Run("add/rm clients", func(c *qt.C) {
-		err := App().Run([]string{"oniongrok", "client", "new", "test"})
+		err := App().Run([]string{"onionpipe", "client", "new", "test"})
 		c.Assert(err, qt.IsNil)
-		err = App().Run([]string{"oniongrok", "client", "new", "test"})
+		err = App().Run([]string{"onionpipe", "client", "new", "test"})
 		c.Assert(err, qt.ErrorMatches, `client "test" already exists`)
-		err = App().Run([]string{"oniongrok", "client", "new", "test2"})
+		err = App().Run([]string{"onionpipe", "client", "new", "test2"})
 		c.Assert(err, qt.IsNil)
-		err = App().Run([]string{"oniongrok", "client", "new", "test3"})
+		err = App().Run([]string{"onionpipe", "client", "new", "test3"})
 		c.Assert(err, qt.IsNil)
-		err = App().Run([]string{"oniongrok", "client", "rm", "test"})
+		err = App().Run([]string{"onionpipe", "client", "rm", "test"})
 		c.Assert(err, qt.IsNil)
 		in, out, err := os.Pipe()
 		c.Assert(err, qt.IsNil)
 		c.Patch(&os.Stdout, out)
 		go func() {
 			defer out.Close()
-			err := App().Run([]string{"oniongrok", "client"})
+			err := App().Run([]string{"onionpipe", "client"})
 			c.Assert(err, qt.IsNil)
 		}()
 		var clients secrets.ClientsPublic

--- a/app/forward.go
+++ b/app/forward.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/cmars/oniongrok/config"
-	"github.com/cmars/oniongrok/forwarding"
-	"github.com/cmars/oniongrok/secrets"
-	"github.com/cmars/oniongrok/tor"
+	"github.com/cmars/onionpipe/config"
+	"github.com/cmars/onionpipe/forwarding"
+	"github.com/cmars/onionpipe/secrets"
+	"github.com/cmars/onionpipe/tor"
 )
 
 var startTor = func(ctx context.Context, options ...tor.Option) (*tor.Tor, error) {
@@ -30,7 +30,7 @@ type forwardingService interface {
 	Start(ctx context.Context, options ...forwarding.Option) (map[string]string, error)
 }
 
-// Forward sets up and operates oniongrok forwards.
+// Forward sets up and operates onionpipe forwards.
 func Forward(ctx *cli.Context) (cmdErr error) {
 	var fwds []*config.Forward
 	var sec *secrets.Secrets

--- a/app/service.go
+++ b/app/service.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cmars/oniongrok/secrets"
 	"github.com/urfave/cli/v2"
+
+	"github.com/cmars/onionpipe/secrets"
 )
 
 // ListServiceKeys implements the `service ls` command.

--- a/app/service_test.go
+++ b/app/service_test.go
@@ -8,9 +8,9 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/cmars/oniongrok/config"
-	"github.com/cmars/oniongrok/secrets"
-	"github.com/cmars/oniongrok/tor"
+	"github.com/cmars/onionpipe/config"
+	"github.com/cmars/onionpipe/secrets"
+	"github.com/cmars/onionpipe/tor"
 )
 
 func TestServiceCommands(t *testing.T) {
@@ -23,7 +23,7 @@ func TestServiceCommands(t *testing.T) {
 	})
 	home := c.Mkdir()
 	c.Setenv("HOME", home)
-	err := App().Run([]string{"oniongrok", "8080@test"})
+	err := App().Run([]string{"onionpipe", "8080@test"})
 	c.Assert(err, qt.IsNil)
 
 	c.Run("list services", func(c *qt.C) {
@@ -32,7 +32,7 @@ func TestServiceCommands(t *testing.T) {
 		c.Patch(&os.Stdout, out)
 		go func() {
 			defer out.Close()
-			err := App().Run([]string{"oniongrok", "service"})
+			err := App().Run([]string{"onionpipe", "service"})
 			c.Assert(err, qt.IsNil)
 		}()
 		var services secrets.ServicesPublic
@@ -42,20 +42,20 @@ func TestServiceCommands(t *testing.T) {
 		c.Assert(services["test"].Address, qt.Not(qt.Equals), "")
 	})
 	c.Run("add/rm services", func(c *qt.C) {
-		err := App().Run([]string{"oniongrok", "service", "new", "test"})
+		err := App().Run([]string{"onionpipe", "service", "new", "test"})
 		c.Assert(err, qt.ErrorMatches, `service "test" already exists`)
-		err = App().Run([]string{"oniongrok", "service", "new", "test2"})
+		err = App().Run([]string{"onionpipe", "service", "new", "test2"})
 		c.Assert(err, qt.IsNil)
-		err = App().Run([]string{"oniongrok", "service", "new", "test3"})
+		err = App().Run([]string{"onionpipe", "service", "new", "test3"})
 		c.Assert(err, qt.IsNil)
-		err = App().Run([]string{"oniongrok", "service", "rm", "test"})
+		err = App().Run([]string{"onionpipe", "service", "rm", "test"})
 		c.Assert(err, qt.IsNil)
 		in, out, err := os.Pipe()
 		c.Assert(err, qt.IsNil)
 		c.Patch(&os.Stdout, out)
 		go func() {
 			defer out.Close()
-			err := App().Run([]string{"oniongrok", "service"})
+			err := App().Run([]string{"onionpipe", "service"})
 			c.Assert(err, qt.IsNil)
 		}()
 		var services secrets.ServicesPublic

--- a/examples/nextcloud/docker-compose.yml
+++ b/examples/nextcloud/docker-compose.yml
@@ -3,15 +3,15 @@ version: '3'
 volumes:
   nextcloud:
   db:
-  oniongrok:
+  onionpipe:
 
 services:
-  oniongrok:
-    image: ghcr.io/cmars/oniongrok:main
+  onionpipe:
+    image: ghcr.io/cmars/onionpipe:main
     restart: always
-    command: --secrets /var/lib/oniongrok/secrets.json app:80~80@nextcloud
+    command: --secrets /var/lib/onionpipe/secrets.json app:80~80@nextcloud
     volumes:
-      - oniongrok:/var/lib/oniongrok
+      - onionpipe:/var/lib/onionpipe
 
   db:
     image: postgres

--- a/forwarding/service.go
+++ b/forwarding/service.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cretz/bine/tor"
 	"golang.org/x/crypto/ed25519"
 
-	"github.com/cmars/oniongrok/config"
+	"github.com/cmars/onionpipe/config"
 )
 
 // Service implements a forwarding service. It sets up and operates forwarding

--- a/forwarding/service_test.go
+++ b/forwarding/service_test.go
@@ -16,9 +16,9 @@ import (
 	qt "github.com/frankban/quicktest"
 	"golang.org/x/net/context/ctxhttp"
 
-	"github.com/cmars/oniongrok/config"
-	"github.com/cmars/oniongrok/forwarding"
-	"github.com/cmars/oniongrok/tor"
+	"github.com/cmars/onionpipe/config"
+	"github.com/cmars/onionpipe/forwarding"
+	"github.com/cmars/onionpipe/tor"
 )
 
 const skipForwardingTests = "SKIP_FORWARDING_TESTS"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cmars/oniongrok
+module github.com/cmars/onionpipe
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/cmars/oniongrok/app"
+	"github.com/cmars/onionpipe/app"
 )
 
 func main() {

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/crypto/nacl/box"
 )
 
-// Secrets represents the format for storing oniongrok secret keys.
+// Secrets represents the format for storing onionpipe secret keys.
 type Secrets struct {
 	Version     string                   `json:"version"`
 	ServiceKeys map[string][]byte        `json:"serviceKeys"`

--- a/tor/init_embed.go
+++ b/tor/init_embed.go
@@ -15,7 +15,7 @@ var fs embed.FS
 
 var torPath string
 
-// init configures oniongrok to use an embedded tor static binary. The binary
+// init configures onionpipe to use an embedded tor static binary. The binary
 // is extracted to a temporary directory and executed from there. This is
 // currently a work in progress and not yet ready for distribution.
 func init() {

--- a/tor/init_libtor.go
+++ b/tor/init_libtor.go
@@ -8,7 +8,7 @@ import (
 )
 
 // init uses libtor directly in the same process, rather than by controlling a
-// tor executable. This configuration allows oniongrok to run as a single executable
+// tor executable. This configuration allows onionpipe to run as a single executable
 // with no unpacking required, but has some quirks:
 //
 // libtor is not as up-to-date with the latest Tor release. It may be missing


### PR DESCRIPTION
Trademark disputes can leave a project like this one vulnerable to
seizure and takeover by well-funded parties.

Even though "onion" is a vegetable and "grok" is jargon-speak, best to
steer clear. Those who have the most gold will write the rules.

So this project is rebranding as onionpipe. Which is probably a better
name and brand for what this is anyway.

BREAKING CHANGE: rename of all packages & artifacts.