### PR TITLE
fix:fix debian version mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Build image
-FROM debian:11 AS tor
+FROM debian:12 AS tor
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq && apt-get install -y apt-transport-https wget gnupg
-RUN echo "deb [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bullseye main" >/etc/apt/sources.list.d/tor.list
+RUN echo "deb [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bookworm main" >/etc/apt/sources.list.d/tor.list
 RUN wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --dearmor | tee /usr/share/keyrings/tor-archive-keyring.gpg >/dev/null
 RUN apt-get update -qq && apt-get install -y tor deb.torproject.org-keyring
 


### PR DESCRIPTION
When running main or latest/v1.1.1 I get a libc version error. This is due to compiling onionpipe on debian 12 and then running it on debian 11. This fix brings the versions into alignment.