### PR TITLE
fix: make /data a volume, fix nextcloud example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,12 @@ RUN go mod download
 COPY . /src/
 ENV SKIP_FORWARDING_TESTS=1
 RUN make all test
-WORKDIR /data
-RUN touch /data/.build
 
 # Deploy image
 FROM tor
+RUN useradd --create-home -d /data -s /bin/bash onionpipe
 COPY --from=build /src/onionpipe /onionpipe
-COPY --from=build --chown=1000 /data/ /data/
+VOLUME [ "/data" ]
 WORKDIR /data
-USER 1000
+USER onionpipe
 ENTRYPOINT [ "/onionpipe" ]

--- a/examples/nextcloud/docker-compose.yml
+++ b/examples/nextcloud/docker-compose.yml
@@ -9,17 +9,15 @@ services:
   onionpipe:
     image: ghcr.io/cmars/onionpipe:main
     restart: always
-    command: --secrets /var/lib/onionpipe/secrets.json app:80~80@nextcloud
+    command: --secrets /data/secrets.json app:80~80@nextcloud
     volumes:
-      - onionpipe:/var/lib/onionpipe
+      - onionpipe:/data
 
   db:
     image: postgres
     restart: always
     volumes:
       - db:/var/lib/postgresql/data
-    ports:
-      - '5432'
     environment:
       - POSTGRES_USER=nextcloud
       - POSTGRES_PASSWORD=changeme
@@ -28,8 +26,6 @@ services:
   app:
     image: nextcloud
     restart: always
-    ports:
-      - 8080:80
     links:
       - db
     volumes:


### PR DESCRIPTION
Partially fixes #25. 

Persistence of data accross docker run invocations is cumbersome (I guess that is not what it is intended for).