### PR TITLE
chore: update goreleaser to v2

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -38,10 +38,11 @@ jobs:
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
+        if: ${{ steps.tag.outputs.new == "true" }}
         with:
           distribution: goreleaser
-          version: latest
-          args: release --rm-dist
+          version: 'v2'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
Breaking change in goreleaser v2 command line args.

Pin to major version v2.