### PR TITLE
fix: goreleaser release automation

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -30,8 +30,9 @@ jobs:
       - name: Bump tag if necessary
         id: tag
         run: |
-          if [ -z $(git tag -l $(git-semver)) ]; then
-            git tag $(git-semver)
+          nextver=v$(git-semver)
+          if [ -z $(git tag -l ${nextver}) ]; then
+            git tag ${nextver}
             git push --tags
             echo "new=true" >> $GITHUB_OUTPUT
           fi

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 builds:
 - id: onionpipe
   binary: onionpipe
@@ -9,7 +10,8 @@ builds:
   - amd64
 
 brews:
-- tap:
+- name: onionpipe
+  repository:
     owner: cmars
     name: homebrew-onionpipe
     branch: main


### PR DESCRIPTION
Use git-semver instead of ccv which fails to choose the next version correctly.

Update goreleaser config to support v2.